### PR TITLE
Kerl fixes according to the official spec

### DIFF
--- a/src/aux.c
+++ b/src/aux.c
@@ -38,6 +38,12 @@ void specific_243trits_to_49trints(int8_t *trits, int8_t *trints_r) {
     }
 }
 
+void trits_to_trints(const trit_t *trits, trint_t *trints, size_t num_trits) {
+    for (uint8_t i = 0; i < (num_trits / 243); i++) {
+        specific_243trits_to_49trints(trits + i * 243, trints + i * 49);
+    }
+}
+
 void specific_49trints_to_243trits(int8_t *trints, int8_t *trits_r) {
     for(uint8_t i = 0; i < 48; i++) {
         //convert 1 trint into 5 trits
@@ -45,6 +51,12 @@ void specific_49trints_to_243trits(int8_t *trints, int8_t *trits_r) {
     }
     //do one more but this will only be 3 trits
     trint_to_trits(trints[48], &trits_r[48 * 5], 3);
+}
+
+void trints_to_trits(const trint_t *trints, trit_t *trits, size_t num_trints) {
+    for (uint8_t i = 0; i < (num_trints / 49); i++) {
+        specific_49trints_to_243trits(trints + i * 49, trits + i * 243);
+    }
 }
 
 void trint_to_trits(int8_t integ, int8_t *trits_r, int8_t sz) {

--- a/src/aux.h
+++ b/src/aux.h
@@ -13,6 +13,8 @@
 
 extern char debug_str[];
 
+void trits_to_trints(const trit_t *trits, trint_t *trints, size_t num_trits);
+void trints_to_trits(const trint_t *trints, trit_t *trits, size_t num_trits);
 void specific_243trits_to_49trints(int8_t *trits, int8_t *trints_r);
 void specific_49trints_to_243trits(int8_t *trints, int8_t *trits_r);
 void trint_to_trits(int8_t integ, int8_t *trits_r, int8_t sz) __attribute__((always_inline));

--- a/src/vendor/iota/conversion.c
+++ b/src/vendor/iota/conversion.c
@@ -230,13 +230,6 @@ int words_to_trints(const int32_t words_in[], trint_t *trints_out)
 }
 
 // ---- NEED ALL BELOW FOR TRITS_TO_WORDS AS WELL AS ALL _U FUNCS IN BIGINT
-//probably convert since ledger doesn't have uint64
-uint32_t swap32(uint32_t i) {
-    return ((i & 0xFF) << 24) |
-    ((i & 0xFF00) << 8) |
-    ((i >> 8) & 0xFF00) |
-    ((i >> 24) & 0xFF);
-}
 
 int trints_to_words_u_mem(const trint_t *trints_in, uint32_t *base)
 {
@@ -302,11 +295,6 @@ int trints_to_words_u_mem(const trint_t *trints_in, uint32_t *base)
         uint32_t base_tmp = base[i];
         base[i] = base[11-i];
         base[11-i] = base_tmp;
-    }
-
-    //swap endianness
-    for(uint8_t i=0; i<12; i++) {
-        base[i] = swap32(base[i]);
     }
 
     //outputs correct words according to official js
@@ -388,11 +376,6 @@ int trints_to_words_u(const trint_t trints_in[], uint32_t words_out[])
         base[11-i] = base_tmp;
     }
 
-    //swap endianness
-    for(uint8_t i=0; i<12; i++) {
-        base[i] = swap32(base[i]);
-    }
-
     //outputs correct words according to official js
     memcpy(words_out, base, 48);
     return 0;
@@ -460,11 +443,6 @@ int trits_to_words_u(const trit_t trits_in[], uint32_t words_out[])
         base_tmp = base[i];
         base[i] = base[11-i];
         base[11-i] = base_tmp;
-    }
-
-    //swap endianness
-    for(uint8_t i=0; i<12; i++) {
-        base[i] = swap32(base[i]);
     }
 
     //outputs correct words according to official js

--- a/src/vendor/iota/conversion.c
+++ b/src/vendor/iota/conversion.c
@@ -85,31 +85,6 @@ int trytes_to_chars(const tryte_t trytes_in[], char chars_out[], uint16_t len)
     return 0;
 }
 
-int bytes_to_words(const unsigned char bytes_in[], uint32_t words_out[], uint8_t word_len)
-{
-    for (int8_t i = word_len - 1; i >= 0; i--) {
-        words_out[i] = 0;
-        words_out[i] |= (bytes_in[(i)*4+3] << 24) & 0xFF000000;
-        words_out[i] |= (bytes_in[(i)*4+2] << 16) & 0x00FF0000;
-        words_out[i] |= (bytes_in[(i)*4+1] <<  8) & 0x0000FF00;
-        words_out[i] |= (bytes_in[(i)*4+0] <<  0) & 0x000000FF;
-    }
-    return 0;
-}
-
-int words_to_bytes(const uint32_t words_in[], unsigned char bytes_out[], uint8_t word_len)
-{
-    for (int8_t i = word_len - 1; i >= 0; i--) {
-      uint32_t value = words_in[i];
-      bytes_out[i*4+0] = (value & 0x000000ff);
-      bytes_out[i*4+1] = (value & 0x0000ff00) >> 8;
-      bytes_out[i*4+2] = (value & 0x00ff0000) >> 16;
-      bytes_out[i*4+3] = (value & 0xff000000) >> 24;
-    }
-
-    return 0;
-}
-
 //custom conversion straight from trints to words
 int trints_to_words(trint_t *trints_in, int32_t words_out[])
 {

--- a/src/vendor/iota/conversion.h
+++ b/src/vendor/iota/conversion.h
@@ -24,9 +24,6 @@ int words_to_trits(const int32_t words_in[], trit_t trits_out[]);
 int trits_to_words_u(const trit_t trits_in[], uint32_t words_out[]);
 int words_to_trits_u(const uint32_t words_in[], trit_t trits_out[]);
 
-int bytes_to_words(const unsigned char bytes_in[], uint32_t words_out[], uint8_t word_len);
-int words_to_bytes(const uint32_t words_in[], unsigned char bytes_out[], uint8_t word_len);
-
 int trints_to_words(trint_t *trints_in, int32_t words_out[]);
 int words_to_trints(const int32_t words_in[], trint_t *trints_out);
 

--- a/src/vendor/iota/kerl.c
+++ b/src/vendor/iota/kerl.c
@@ -25,6 +25,13 @@ int kerl_finalize(unsigned char *bytes_out, uint16_t len)
     return 0;
 }
 
+uint32_t change_endianess(uint32_t i) {
+    return ((i & 0xFF) << 24) |
+    ((i & 0xFF00) << 8) |
+    ((i >> 8) & 0xFF00) |
+    ((i >> 24) & 0xFF);
+}
+
 //absorbing trits happens in 243 trit chunks
 int kerl_absorb_trits(trit_t *trits_in, uint16_t len)
 {
@@ -33,7 +40,14 @@ int kerl_absorb_trits(trit_t *trits_in, uint16_t len)
         int32_t words[12];
         unsigned char bytes[48];
         trits_to_words_u(trits_in, words);
-        words_to_bytes(words, bytes, 12);
+
+        // swap endianness on little-endian hardware
+        for(uint8_t i=0; i<12; i++) {
+            words[i] = change_endianess(words[i]);
+        }
+        memcpy(bytes, words, 48);
+        // words_to_bytes(words, bytes, 12);
+
         kerl_absorb_bytes(bytes, 48);
     }
     return 0;
@@ -46,8 +60,14 @@ int kerl_squeeze_trits(trit_t trits_out[], uint16_t len)
     int32_t words[12];
 
     kerl_finalize(bytes_out, 48);
-    
-    bytes_to_words(bytes_out, words, 12);
+
+    // swap endianness on little-endian hardware
+    memcpy(words, bytes_out, 48);
+    for(uint8_t i=0; i<12; i++) {
+        words[i] = change_endianess(words[i]);
+    }
+    // bytes_to_words(bytes_out, words, 12);
+
     words_to_trits_u(words, trits_out);
 
     // Last trit zero
@@ -76,7 +96,14 @@ int kerl_absorb_trints(trint_t *trints_in, uint16_t len)
         unsigned char bytes[48];
         //Convert straight from trints to words
         trints_to_words_u_mem(trints_in, words);
-        words_to_bytes(words, bytes, 12);
+
+        // swap endianness on little-endian hardware
+        for(uint8_t i=0; i<12; i++) {
+            words[i] = change_endianess(words[i]);
+        }
+        memcpy(bytes, words, 48);
+        // words_to_bytes(words, bytes, 12);
+
         kerl_absorb_bytes(bytes, 48);
     }
     return 0;
@@ -90,7 +117,13 @@ int kerl_squeeze_trints(trint_t *trints_out, uint16_t len)
 
     kerl_finalize(bytes_out, 48);
 
-    bytes_to_words(bytes_out, words, 12);
+    // swap endianness on little-endian hardware
+    memcpy(words, bytes_out, 48);
+    for(uint8_t i=0; i<12; i++) {
+        words[i] = change_endianess(words[i]);
+    }
+    // bytes_to_words(bytes_out, words, 12);
+
     words_to_trints_u_mem(words, &trints_out[0]);
 
     //-- Setting last trit to 0

--- a/src/vendor/iota/kerl.c
+++ b/src/vendor/iota/kerl.c
@@ -5,7 +5,7 @@
 
 //sha3 is 424 bytes long
 cx_sha3_t sha3;
-static unsigned char bytes_out[48] = {0};
+static unsigned char sha3_bytes_out[48] = {0};
 
 int kerl_initialize(void)
 {
@@ -15,7 +15,13 @@ int kerl_initialize(void)
 
 int kerl_absorb_bytes(unsigned char *bytes_in, uint16_t len)
 {
-    cx_hash((cx_hash_t *)&sha3, CX_LAST, bytes_in, len, bytes_out);
+    cx_hash((cx_hash_t *)&sha3, CX_LAST, bytes_in, len, sha3_bytes_out);
+    return 0;
+}
+
+int kerl_finalize(unsigned char *bytes_out, uint16_t len)
+{
+    memcpy(bytes_out, sha3_bytes_out, len);
     return 0;
 }
 
@@ -36,10 +42,11 @@ int kerl_absorb_trits(trit_t *trits_in, uint16_t len)
 
 int kerl_squeeze_trits(trit_t trits_out[], uint16_t len)
 {
-    (void) len;
+    unsigned char bytes_out[48];
+    int32_t words[12];
 
-    // Convert to trits
-    int32_t words[12] = {0};
+    kerl_finalize(bytes_out, 48);
+    
     bytes_to_words(bytes_out, words, 12);
     words_to_trits_u(words, trits_out);
 
@@ -76,9 +83,13 @@ int kerl_absorb_trints(trint_t *trints_in, uint16_t len)
 }
 
 //utilize encoded format
-int kerl_squeeze_trints(trint_t *trints_out, uint16_t len) {
-    // Convert to trits
-    uint32_t words[12];
+int kerl_squeeze_trints(trint_t *trints_out, uint16_t len)
+{
+    unsigned char bytes_out[48];
+    int32_t words[12];
+
+    kerl_finalize(bytes_out, 48);
+
     bytes_to_words(bytes_out, words, 12);
     words_to_trints_u_mem(words, &trints_out[0]);
 


### PR DESCRIPTION
Align `kerl.c` with the official  [Kerl Specification]( https://github.com/iotaledger/kerl/blob/master/IOTA-Kerl-spec.md) especially for input/output consisting of more than one 243-chunk of trits.

These fixes have been tested with the trezor-crypto keccak-implementation on an intel CPU. However, the following potential issues remain:
- Code needs to be adapted for the Endianness of the Ledger Hardware. (This is configurable in `kerl.c`)
- Verify correctness of current usage of Ledger keccak-implementation, especially for multiple absorbs when the input is longer than 243 trits.