### PR TITLE
Reduce address generation memory usage

### DIFF
--- a/src/iota/addresses.c
+++ b/src/iota/addresses.c
@@ -78,11 +78,11 @@ void get_public_addr(const unsigned char *seed_bytes, uint32_t idx,
 
         // save as much memory as humanly possible
         if (i == 0)
-            kerl_squeeze_chunk(&digest_sha, digest);
+            kerl_squeeze_final_chunk(&digest_sha, digest);
         else if (i == 1) // temp store
-            kerl_squeeze_chunk(&digest_sha, address_bytes);
+            kerl_squeeze_final_chunk(&digest_sha, address_bytes);
         else // the last chunk can go into key_f (won't need key_f again)
-            kerl_squeeze_chunk(&digest_sha, key_f);
+            kerl_squeeze_final_chunk(&digest_sha, key_f);
 
         // reset digest sha for next digest
         kerl_initialize(&digest_sha);

--- a/src/iota/addresses.c
+++ b/src/iota/addresses.c
@@ -3,18 +3,8 @@
 #include "conversion.h"
 #include "kerl.h"
 
-static void digest_addr(cx_sha3_t *digest_sha3, cx_sha3_t *addr_sha3) {
-    unsigned char digest[48];
-    kerl_squeeze_chunk(digest_sha3, digest);
-
-    //keep a running absorb on all digest chunks
-    kerl_absorb_chunk(addr_sha3, digest);
-
-    //reset digest sha for next digest
-    kerl_initialize(digest_sha3);
-}
-
-static void digest_single_chunk(const unsigned char *key, cx_sha3_t *digest_sha3)
+static void digest_single_chunk(const unsigned char *key,
+                                cx_sha3_t *digest_sha3)
 {
     cx_sha3_t round_sha3;
     unsigned char buffer[48];
@@ -27,14 +17,15 @@ static void digest_single_chunk(const unsigned char *key, cx_sha3_t *digest_sha3
         kerl_squeeze_final_chunk(&round_sha3, buffer);
     }
 
-    // asorb buffer directly to avoid storing the digest fragment
+    // absorb buffer directly to avoid storing the digest fragment
     kerl_absorb_chunk(digest_sha3, buffer);
 }
 
-//initialize the sha3 instance for generating private key
-void init_shas(const unsigned char *seed_bytes, uint32_t idx, cx_sha3_t *key_sha,
-                      cx_sha3_t *digest_sha, cx_sha3_t *addr_sha) {
-    //use temp bigint so seed not destroyed
+// initialize the sha3 instance for generating private key
+void init_shas(const unsigned char *seed_bytes, uint32_t idx,
+               cx_sha3_t *key_sha, cx_sha3_t *digest_sha)
+{
+    // use temp bigint so seed not destroyed
     unsigned char bytes[48];
     os_memcpy(bytes, seed_bytes, sizeof(bytes));
 
@@ -48,23 +39,26 @@ void init_shas(const unsigned char *seed_bytes, uint32_t idx, cx_sha3_t *key_sha
     kerl_absorb_chunk(key_sha, bytes);
 
     kerl_initialize(digest_sha);
-    kerl_initialize(addr_sha);
 }
 
-//create a couple instances of sha3 and keep them running.
+// generate public address in byte format
 void get_public_addr(const unsigned char *seed_bytes, uint32_t idx,
                      uint8_t security, unsigned char *address_bytes)
 {
-    //sha size is 424 bytes
-    cx_sha3_t key_sha, digest_sha, addr_sha;
+    // sha size is 424 bytes
+    cx_sha3_t key_sha, digest_sha;
 
-    //init private key sha, digest sha and addr sha
-    init_shas(seed_bytes, idx, &key_sha, &digest_sha, &addr_sha);
+    // init private key sha, digest sha and addr sha
+    init_shas(seed_bytes, idx, &key_sha, &digest_sha);
 
 
     //only store a single fragment of the private key at a time and use it to completion
     //before moving onto next fragment to store memory
     unsigned char key_f[48];
+
+    // max security is 3, so digest can store first chunk, address_bytes can
+    // store second, and key_f can store third
+    unsigned char digest[48];
 
     for(uint8_t i=0; i<security; i++) {
         for(uint8_t j=0; j<27; j++) {
@@ -73,9 +67,30 @@ void get_public_addr(const unsigned char *seed_bytes, uint32_t idx,
             digest_single_chunk(key_f, &digest_sha);
         }
 
-        digest_addr(&digest_sha, &addr_sha);
+        //save as much memory as humanly possible
+        if(i == 0)
+            kerl_squeeze_chunk(&digest_sha, digest);
+        else if(i == 1) //temp store
+            kerl_squeeze_chunk(&digest_sha, address_bytes);
+        else //the last chunk can go into key_f (won't need key_f again)
+            kerl_squeeze_chunk(&digest_sha, key_f);
+
+        // reset digest sha for next digest
+        kerl_initialize(&digest_sha);
     }
 
-    //one final squeeze for address
-    kerl_squeeze_final_chunk(&addr_sha, address_bytes);
+    //reuse digest_sha to produce the address
+    kerl_initialize(&digest_sha);
+
+    for(uint8_t i = 0; i < security; i++) {
+        if(i == 0)
+            kerl_absorb_chunk(&digest_sha, digest);
+        else if(i == 1)
+            kerl_absorb_chunk(&digest_sha, address_bytes);
+        else
+            kerl_absorb_chunk(&digest_sha, key_f);
+    }
+
+    // one final squeeze for address
+    kerl_squeeze_final_chunk(&digest_sha, address_bytes);
 }

--- a/src/iota/addresses.c
+++ b/src/iota/addresses.c
@@ -4,17 +4,18 @@
 #include "kerl.h"
 
 static void digest_single_chunk(const unsigned char *key,
-                                cx_sha3_t *digest_sha3)
+                                cx_sha3_t *digest_sha3, cx_sha3_t *round_sha3)
 {
-    cx_sha3_t round_sha3;
     unsigned char buffer[48];
 
     os_memcpy(buffer, key, sizeof(buffer));
+    // key will not have last trit set to 0, so set it to 0 in buffer
+    bytes_set_last_trit_zero(buffer);
 
     for (int k = 0; k < 26; k++) {
-        kerl_initialize(&round_sha3);
-        kerl_absorb_chunk(&round_sha3, buffer);
-        kerl_squeeze_final_chunk(&round_sha3, buffer);
+        kerl_initialize(round_sha3);
+        kerl_absorb_chunk(round_sha3, buffer);
+        kerl_squeeze_final_chunk(round_sha3, buffer);
     }
 
     // absorb buffer directly to avoid storing the digest fragment
@@ -48,7 +49,7 @@ void get_public_addr(const unsigned char *seed_bytes, uint32_t idx,
     // sha size is 424 bytes
     cx_sha3_t key_sha, digest_sha;
 
-    // init private key sha, digest sha and addr sha
+    // init private key sha, digest sha
     init_shas(seed_bytes, idx, &key_sha, &digest_sha);
 
 
@@ -56,15 +57,21 @@ void get_public_addr(const unsigned char *seed_bytes, uint32_t idx,
     //before moving onto next fragment to store memory
     unsigned char key_f[48];
 
+    // ---- If we limit the security level to 2 (for whatever reason)
+    // we can cut out 48 more bytes with digest[48]
+
     // max security is 3, so digest can store first chunk, address_bytes can
     // store second, and key_f can store third
     unsigned char digest[48];
 
-    for(uint8_t i=0; i<security; i++) {
-        for(uint8_t j=0; j<27; j++) {
-            //generate every private key frag, and absorb them
-            kerl_squeeze_chunk(&key_sha, key_f);
-            digest_single_chunk(key_f, &digest_sha);
+    for (uint8_t i = 0; i < security; i++) {
+        for (uint8_t j = 0; j < 27; j++) {
+            //cheat the squeeze (last trit not set to 0, nor are bytes flipped/reabsorbed)
+            kerl_squeeze_cheat(&key_sha, key_f);
+            //re-use key_sha as round_sha
+            digest_single_chunk(key_f, &digest_sha, &key_sha);
+            //now that we've reused the key_sha, we can reinitialize it with our key_f
+            kerl_absorb_cheat(&key_sha, key_f);
         }
 
         //save as much memory as humanly possible
@@ -82,6 +89,7 @@ void get_public_addr(const unsigned char *seed_bytes, uint32_t idx,
     //reuse digest_sha to produce the address
     kerl_initialize(&digest_sha);
 
+    //go through and absorb chunks from each different piece of memory
     for(uint8_t i = 0; i < security; i++) {
         if(i == 0)
             kerl_absorb_chunk(&digest_sha, digest);

--- a/src/iota/addresses.c
+++ b/src/iota/addresses.c
@@ -53,8 +53,8 @@ void get_public_addr(const unsigned char *seed_bytes, uint32_t idx,
     init_shas(seed_bytes, idx, &key_sha, &digest_sha);
 
 
-    //only store a single fragment of the private key at a time and use it to completion
-    //before moving onto next fragment to store memory
+    // only store a single fragment of the private key at a time and use it to
+    // completion  before moving onto next fragment to store memory
     unsigned char key_f[48];
 
     // ---- If we limit the security level to 2 (for whatever reason)
@@ -66,34 +66,34 @@ void get_public_addr(const unsigned char *seed_bytes, uint32_t idx,
 
     for (uint8_t i = 0; i < security; i++) {
         for (uint8_t j = 0; j < 27; j++) {
-            //cheat the squeeze (last trit not set to 0, nor are bytes flipped/reabsorbed)
+            // cheat the squeeze (last trit not set to 0, nor are bytes
+            // flipped/reabsorbed)
             kerl_squeeze_cheat(&key_sha, key_f);
-            //re-use key_sha as round_sha
+            // re-use key_sha as round_sha
             digest_single_chunk(key_f, &digest_sha, &key_sha);
-            //now that we've reused the key_sha, we can reinitialize it with our key_f
+            // now that we've reused the key_sha, we can reinitialize it with
+            // our key_f
             kerl_absorb_cheat(&key_sha, key_f);
         }
 
-        //save as much memory as humanly possible
-        if(i == 0)
+        // save as much memory as humanly possible
+        if (i == 0)
             kerl_squeeze_chunk(&digest_sha, digest);
-        else if(i == 1) //temp store
+        else if (i == 1) // temp store
             kerl_squeeze_chunk(&digest_sha, address_bytes);
-        else //the last chunk can go into key_f (won't need key_f again)
+        else // the last chunk can go into key_f (won't need key_f again)
             kerl_squeeze_chunk(&digest_sha, key_f);
 
         // reset digest sha for next digest
         kerl_initialize(&digest_sha);
     }
 
-    //reuse digest_sha to produce the address
-    kerl_initialize(&digest_sha);
-
-    //go through and absorb chunks from each different piece of memory
-    for(uint8_t i = 0; i < security; i++) {
-        if(i == 0)
+    // digest_sha will be reused - and is already reinitialized for final
+    // address go through and absorb chunks from each different piece of memory
+    for (uint8_t i = 0; i < security; i++) {
+        if (i == 0)
             kerl_absorb_chunk(&digest_sha, digest);
-        else if(i == 1)
+        else if (i == 1)
             kerl_absorb_chunk(&digest_sha, address_bytes);
         else
             kerl_absorb_chunk(&digest_sha, key_f);

--- a/src/iota/addresses.c
+++ b/src/iota/addresses.c
@@ -55,7 +55,8 @@ void get_public_addr(const unsigned char *seed_bytes, uint32_t idx,
 
     for (uint8_t i = 0; i < security; i++) {
         for (uint8_t j = 0; j < 27; j++) {
-            unsigned char state[48];
+            // use address output array as a temp Kerl state storage
+            unsigned char *state = address_bytes;
 
             // the state takes only 48bytes and allows us to reuse key_sha
             kerl_state_squeeze_chunk(&key_sha, state, key_f);

--- a/src/iota/kerl.c
+++ b/src/iota/kerl.c
@@ -47,14 +47,6 @@ void kerl_squeeze_chunk(cx_sha3_t *sha3, unsigned char *bytes_out)
     kerl_absorb_chunk(sha3, hash);
 }
 
-void kerl_squeeze_cheat(cx_sha3_t *sha3, unsigned char *bytes_out)
-{
-    cx_hash((cx_hash_t *)sha3, CX_LAST, bytes_out, 0, bytes_out);
-    
-    // flip bytes for multiple squeeze
-    flip_hash_bytes(bytes_out);
-}
-
 void kerl_squeeze_bytes(cx_sha3_t *sha3, unsigned char *bytes, unsigned int len)
 {
     unsigned char *chunk = bytes;
@@ -64,4 +56,18 @@ void kerl_squeeze_bytes(cx_sha3_t *sha3, unsigned char *bytes, unsigned int len)
         kerl_squeeze_chunk(sha3, chunk);
         chunk += NUM_HASH_BYTES;
     }
+}
+
+void kerl_squeeze_cheat(cx_sha3_t *sha3, unsigned char *bytes_out)
+{
+    cx_hash((cx_hash_t *)sha3, CX_LAST, bytes_out, 0, bytes_out);
+}
+
+void kerl_absorb_cheat(cx_sha3_t *sha3, unsigned char *bytes_in)
+{
+    // flip bytes for multiple squeeze
+    flip_hash_bytes(bytes_in);
+    
+    kerl_initialize(sha3);
+    kerl_absorb_chunk(sha3, bytes_in);
 }

--- a/src/iota/kerl.c
+++ b/src/iota/kerl.c
@@ -47,6 +47,14 @@ void kerl_squeeze_chunk(cx_sha3_t *sha3, unsigned char *bytes_out)
     kerl_absorb_chunk(sha3, hash);
 }
 
+void kerl_squeeze_cheat(cx_sha3_t *sha3, unsigned char *bytes_out)
+{
+    cx_hash((cx_hash_t *)sha3, CX_LAST, bytes_out, 0, bytes_out);
+    
+    // flip bytes for multiple squeeze
+    flip_hash_bytes(bytes_out);
+}
+
 void kerl_squeeze_bytes(cx_sha3_t *sha3, unsigned char *bytes, unsigned int len)
 {
     unsigned char *chunk = bytes;

--- a/src/iota/kerl.c
+++ b/src/iota/kerl.c
@@ -5,7 +5,16 @@
 // number of bytes in one keccak hash
 #define NUM_HASH_BYTES 48
 
-void kerl_initialize(cx_sha3_t *sha3) { cx_keccak_init(sha3, 384); }
+void kerl_initialize(cx_sha3_t *sha3)
+{
+    cx_keccak_init(sha3, 384);
+}
+
+void kerl_reinitialize(cx_sha3_t *sha3, const unsigned char *state_bytes)
+{
+    kerl_initialize(sha3);
+    kerl_absorb_chunk(sha3, state_bytes);
+}
 
 void kerl_absorb_bytes(cx_sha3_t *sha3, const unsigned char *bytes,
                        unsigned int len)
@@ -24,50 +33,37 @@ void kerl_squeeze_final_chunk(cx_sha3_t *sha3, unsigned char *bytes_out)
     bytes_set_last_trit_zero(bytes_out);
 }
 
-static inline void flip_hash_bytes(unsigned char *bytes)
-{
-    for (int i = 0; i < NUM_HASH_BYTES; i++) {
-        bytes[i] = ~bytes[i];
-    }
-}
-
 void kerl_squeeze_chunk(cx_sha3_t *sha3, unsigned char *bytes_out)
 {
-    unsigned char hash[NUM_HASH_BYTES];
+    unsigned char state_bytes[NUM_HASH_BYTES];
 
-    cx_hash((cx_hash_t *)sha3, CX_LAST, hash, 0, hash);
-
-    os_memcpy(bytes_out, hash, sizeof(hash));
-    bytes_set_last_trit_zero(bytes_out);
-
-    // flip bytes for multiple squeeze
-    flip_hash_bytes(hash);
-
-    kerl_initialize(sha3);
-    kerl_absorb_chunk(sha3, hash);
+    kerl_state_squeeze_chunk(sha3, state_bytes, bytes_out);
+    kerl_reinitialize(sha3, state_bytes);
 }
 
 void kerl_squeeze_bytes(cx_sha3_t *sha3, unsigned char *bytes, unsigned int len)
 {
-    unsigned char *chunk = bytes;
-
     // absorbing happens in 48 word bigint chunks
     for (unsigned int i = 0; i < (len / NUM_HASH_BYTES); i++) {
-        kerl_squeeze_chunk(sha3, chunk);
-        chunk += NUM_HASH_BYTES;
+        kerl_squeeze_chunk(sha3, bytes + NUM_HASH_BYTES * i);
     }
 }
 
-void kerl_squeeze_cheat(cx_sha3_t *sha3, unsigned char *bytes_out)
+static inline void flip_hash_bytes(unsigned char *bytes)
 {
-    cx_hash((cx_hash_t *)sha3, CX_LAST, bytes_out, 0, bytes_out);
+    for (unsigned int i = 0; i < NUM_HASH_BYTES; i++) {
+        bytes[i] = ~bytes[i];
+    }
 }
 
-void kerl_absorb_cheat(cx_sha3_t *sha3, unsigned char *bytes_in)
+void kerl_state_squeeze_chunk(cx_sha3_t *sha3, unsigned char *state_bytes,
+                              unsigned char *bytes_out)
 {
-    // flip bytes for multiple squeeze
-    flip_hash_bytes(bytes_in);
+    cx_hash((cx_hash_t *)sha3, CX_LAST, state_bytes, 0, state_bytes);
 
-    kerl_initialize(sha3);
-    kerl_absorb_chunk(sha3, bytes_in);
+    os_memcpy(bytes_out, state_bytes, NUM_HASH_BYTES);
+    bytes_set_last_trit_zero(bytes_out);
+
+    // flip bytes for multiple squeeze
+    flip_hash_bytes(state_bytes);
 }

--- a/src/iota/kerl.c
+++ b/src/iota/kerl.c
@@ -67,7 +67,7 @@ void kerl_absorb_cheat(cx_sha3_t *sha3, unsigned char *bytes_in)
 {
     // flip bytes for multiple squeeze
     flip_hash_bytes(bytes_in);
-    
+
     kerl_initialize(sha3);
     kerl_absorb_chunk(sha3, bytes_in);
 }

--- a/src/iota/kerl.h
+++ b/src/iota/kerl.h
@@ -46,4 +46,16 @@ void kerl_squeeze_final_chunk(cx_sha3_t *sha3, unsigned char *bytes_out);
  */
 void kerl_squeeze_bytes(cx_sha3_t *sha3, unsigned char* bytes, unsigned int len);
 
+/** @brief Skip byte flipping, and setting last trit to 0, to reuse sha
+ *  @param sha3 the SHA context used for hashing.
+ *  @param bytes_out the resulting unfinished byte array
+ */
+void kerl_squeeze_cheat(cx_sha3_t *sha3, unsigned char *bytes_out);
+
+/** @brief Reinitialize and reabsorb the cheated squeeze to pick up where we left off
+ *  @param sha3 the SHA context used for hashing.
+ *  @param bytes_in the "cheated" squeezed bytes to reabsorb
+ */
+void kerl_absorb_cheat(cx_sha3_t *sha3, unsigned char *bytes_in);
+
 #endif // KERL_H

--- a/src/iota/kerl.h
+++ b/src/iota/kerl.h
@@ -12,20 +12,28 @@
  */
 void kerl_initialize(cx_sha3_t *sha3);
 
+/** @brief Reinitialize the context with the given Kerl state.
+ *  A reinitialized context can then be used to squeeze further chunks.
+ *  @param sha3 the SHA context used for hashing
+ *  @param state_bytes byte array containing the 48 byte Kerl state
+ */
+void kerl_reinitialize(cx_sha3_t *sha3, const unsigned char *state_bytes);
+
 /** @brief Absorb exactly one chunk of 48 bytes.
- *  @param sha3 the SHA context used for hashing.
+ *  @param sha3 the SHA context used for hashing
  *  @param bytes bytes to absorb.
  */
 void kerl_absorb_chunk(cx_sha3_t *sha3, const unsigned char* bytes);
 
 /** @brief Absorb arbitrary number of bytes.
- *  @param sha3 the SHA context used for hashing.
+ *  @param sha3 the SHA context used for hashing
  *  @param bytes bytes to absorb.
  */
 void kerl_absorb_bytes(cx_sha3_t *sha3, const unsigned char* bytes, unsigned int len);
 
 /** @brief Squeeze exactly one chunk of 48 bytes.
- *  @param sha3 the SHA context used for hashing.
+ *  This function automatically reinitializes kerl in the corresponding state.
+ *  @param sha3 the SHA context used for hashing
  *  @param bytes result byte array
  */
 void kerl_squeeze_chunk(cx_sha3_t *sha3, unsigned char* bytes);
@@ -34,28 +42,25 @@ void kerl_squeeze_chunk(cx_sha3_t *sha3, unsigned char* bytes);
  *         hash context to allow for multiple squeeze.
  *  This funtion should be called, if no further squeeze are performed on this
  *  context, as it avoid unnecessary reinitializations.
- *  @param sha3 the SHA context used for hashing.
+ *  @param sha3 the SHA context used for hashing
  *  @param bytes result byte array
  */
 void kerl_squeeze_final_chunk(cx_sha3_t *sha3, unsigned char *bytes_out);
 
 /** @brief Squeeze multiple chunks of 48 byte data.
- *  @param sha3 the SHA context used for hashing.
+ *  @param sha3 the SHA context used for hashing
  *  @param bytes result byte array
  *  @param len number of bytes to squeeze.
  */
 void kerl_squeeze_bytes(cx_sha3_t *sha3, unsigned char* bytes, unsigned int len);
 
-/** @brief Skip byte flipping, and setting last trit to 0, to reuse sha
- *  @param sha3 the SHA context used for hashing.
- *  @param bytes_out the resulting unfinished byte array
+/** @brief Squeeze exactly one chunk of 48 bytes also returning the kerl state.
+ *  The hash returned is identical to kerl_squeeze_chunk().
+ *  The 48 byte kerl state can then be used in kerl_initialize_squeeze() to put any SHA context in the state.
+ *  @param sha3 the SHA context used for hashing
+ *  @param state_bytes target byte array to store the 48 byte state
+ *  @param bytes result byte array
  */
-void kerl_squeeze_cheat(cx_sha3_t *sha3, unsigned char *bytes_out);
-
-/** @brief Reinitialize and reabsorb the cheated squeeze to pick up where we left off
- *  @param sha3 the SHA context used for hashing.
- *  @param bytes_in the "cheated" squeezed bytes to reabsorb
- */
-void kerl_absorb_cheat(cx_sha3_t *sha3, unsigned char *bytes_in);
+void kerl_state_squeeze_chunk(cx_sha3_t *sha3, unsigned char *state_bytes, unsigned char *bytes);
 
 #endif // KERL_H


### PR DESCRIPTION
- Reuse byte buffers
- Introduce state saving Kerl calls, to reinitialize already used SHA contexts
- Reduce required SHA contexts from 4 to 2, saving 400 bytes each