### PR TITLE
C API: You now have to provide your own metatransactions

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -185,16 +185,8 @@ unsigned int api_tx(const unsigned char *input_data, unsigned int len)
         THROW(SW_COMMAND_INVALID_DATA);
     }
     bundle_add_tx(&api.bundle_ctx, input->value, padded_tag, timestamp);
-
-    if (input->value < 0) {
-        // create meta tx for input
-        bundle_set_external_address(&api.bundle_ctx, input->address);
-        bundle_add_tx(&api.bundle_ctx, 0, padded_tag, timestamp);
-    }
-
     if (!bundle_has_open_txs(&api.bundle_ctx)) {
         ui_sign_tx(&api.bundle_ctx);
-
         return IO_ASYNCH_REPLY;
     }
 

--- a/tests/sign_test.c
+++ b/tests/sign_test.c
@@ -40,6 +40,21 @@ static void input_valid_bundle(uint8_t security)
         memcpy(&input, &PETER_VECTOR.bundle[1], sizeof(input));
 
         TX_OUTPUT output;
+        output.finalized = false;
+
+        EXPECT_API_DATA_OK(tx, input, output);
+    }
+    {
+        // Meta TX
+        TX_INPUT input;
+        memcpy(&input, &PETER_VECTOR.bundle[1], sizeof(input));
+
+        // Changes for Meta TX
+        input.value = 0;
+        input.current_index++;
+        // End Changes for Meta TX
+
+        TX_OUTPUT output;
         output.finalized = true;
         strncpy(output.bundle_hash, PETER_VECTOR.bundle_hash, 81);
 

--- a/tests/tx_test.c
+++ b/tests/tx_test.c
@@ -43,7 +43,21 @@ static void test_valid_output_input_bundle(void **state)
         TX_INPUT input;
         memcpy(&input, &PETER_VECTOR.bundle[1], sizeof(input));
 
-        TX_OUTPUT output;
+        TX_OUTPUT output = {0};
+        output.finalized = false;
+        EXPECT_API_DATA_OK(tx, input, output);
+    }
+    {
+        // Meta TX
+        TX_INPUT input;
+        memcpy(&input, &PETER_VECTOR.bundle[1], sizeof(input));
+
+        // Changes for Meta TX
+        input.value = 0;
+        input.current_index++;
+        // End Changes for Meta TX
+
+        TX_OUTPUT output = {0};
         output.finalized = true;
         strncpy(output.bundle_hash, PETER_VECTOR.bundle_hash, 81);
 
@@ -115,7 +129,16 @@ static void test_invalid_input_address_index(void **state)
 
         EXPECT_API_DATA_OK(tx, input, output);
     }
-    { // input transaciton
+    { // input transaction
+        TX_INPUT input;
+        memcpy(&input, &PETER_VECTOR.bundle[1], sizeof(input));
+        input.address_idx += 1;
+        TX_OUTPUT output = {0};
+        output.finalized = false;
+
+        EXPECT_API_DATA_OK(tx, input, output);
+    }
+    { // input transaction
         TX_INPUT input;
         memcpy(&input, &PETER_VECTOR.bundle[1], sizeof(input));
         input.address_idx += 1;
@@ -135,7 +158,7 @@ static void test_invalid_tx_order(void **state)
         SET_SEED_INPUT input = {BIP32_PATH, security};
         EXPECT_API_OK(set_seed, input);
     }
-    { // input transaciton as the first transaction
+    { // input transaction as the first transaction
         TX_INPUT input;
         memcpy(&input, &PETER_VECTOR.bundle[1], sizeof(input));
         input.current_index = 0;

--- a/tests/tx_test.c
+++ b/tests/tx_test.c
@@ -138,10 +138,12 @@ static void test_invalid_input_address_index(void **state)
 
         EXPECT_API_DATA_OK(tx, input, output);
     }
-    { // input transaction
+    { // meta transaction
         TX_INPUT input;
         memcpy(&input, &PETER_VECTOR.bundle[1], sizeof(input));
         input.address_idx += 1;
+        input.value = 0;
+        input.current_index++;
 
         EXPECT_API_EXCEPTION(tx, input);
     }


### PR DESCRIPTION
 Makes it easier to operate with bundle.js from iota.lib.js and its easier to accomodate for higer security signatures.