### PR TITLE
Use api context as a global variable

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -68,12 +68,9 @@ unsigned int api_set_seed(uint8_t p1, const unsigned char *input_data,
     }
 
     derive_seed_bip32(api.bip32_path, api.bip32_path_length, api.seed_bytes);
-    
-    // give the API to the UI
-    ui_set_api(&api);
-    
+
     api.state_flags |= SEED_SET;
-    
+
     io_send(NULL, 0, SW_OK);
     return 0;
 }

--- a/src/api.h
+++ b/src/api.h
@@ -31,6 +31,9 @@ typedef struct API_CTX {
     unsigned int state_flags;
 } API_CTX;
 
+/// global context with everything related to the current api state
+extern API_CTX api;
+
 typedef IO_STRUCT SET_SEED_INPUT
 {
     int64_t security;

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -129,11 +129,6 @@ void ctx_initialize()
     ui_state.display_full_value = false;
 }
 
-void ui_set_api(API_CTX *api_ctx)
-{
-    ui_state.api_ctx = api_ctx;
-}
-
 void ui_init(bool flash_is_init)
 {
     ctx_initialize();
@@ -180,13 +175,13 @@ void ui_display_validating()
 {
     clear_display();
     write_display("Validating...", TYPE_STR, MID);
-    
+
     display_glyphs(ui_glyphs.glyph_load, NULL);
-    
+
     backup_state();
-    
+
     ui_state.state = STATE_IGNORE;
-    
+
     ui_render();
     ui_force_draw();
 }
@@ -231,10 +226,8 @@ void ui_display_address(const unsigned char *addr_bytes)
     ui_force_draw();
 }
 
-void ui_sign_tx(BUNDLE_CTX *bundle_ctx)
+void ui_sign_tx()
 {
-    ui_state.bundle_ctx = bundle_ctx;
-
     state_go(STATE_PROMPT_TX, 0);
 
     ui_build_display();

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -15,7 +15,6 @@
  - Create msg to display [ui_misc.c]
  - Define behavior (ui_handle_menus) [ui_handling.c] */
 
-void ui_set_api(API_CTX *api_ctx);
 void ui_init(bool flash_is_init);
 
 void ui_display_welcome();
@@ -24,8 +23,7 @@ void ui_display_validating();
 void ui_display_recv();
 void ui_display_signing();
 void ui_display_address(const unsigned char *addr_bytes);
-void ui_set_path(API_CTX *api_ctx);
-void ui_sign_tx(BUNDLE_CTX *bundle_ctx);
+void ui_sign_tx();
 void ui_reset();
 void ui_restore();
 

--- a/src/ui/ui_buttons.c
+++ b/src/ui/ui_buttons.c
@@ -109,7 +109,7 @@ uint8_t button_disp_addr(uint8_t button_mask)
     if (button_mask == BUTTON_L && ui_state.menu_idx == 0) {
         state_go(STATE_DISP_ADDR_CHK, 0);
     }
-    else if(button_mask == BUTTON_R && ui_state.menu_idx == array_sz) {
+    else if (button_mask == BUTTON_R && ui_state.menu_idx == array_sz) {
         state_go(STATE_BIP_PATH, 0);
     }
     else if (button_mask == BUTTON_B) {
@@ -132,8 +132,8 @@ uint8_t button_disp_addr_chk(uint8_t button_mask)
 uint8_t button_tx_addr(uint8_t button_mask)
 {
     uint8_t array_sz = MENU_ADDR_LEN - 1;
-    
-    if(button_mask == BUTTON_R && ui_state.menu_idx == array_sz) {
+
+    if (button_mask == BUTTON_R && ui_state.menu_idx == array_sz) {
         state_go(STATE_BIP_PATH, 0);
     }
     else if (button_mask == BUTTON_B) {
@@ -154,7 +154,7 @@ void button_prompt_tx(uint8_t button_mask)
         // bypass displaying confirmations for meta-tx's
         do {
             ui_state.menu_idx++;
-            val = ui_state.bundle_ctx->values[menu_to_tx_idx()];
+            val = api.bundle_ctx.values[menu_to_tx_idx()];
         } while (val == 0 && ui_state.menu_idx < array_sz - 2);
 
         // loop back to 0
@@ -172,7 +172,7 @@ void button_prompt_tx(uint8_t button_mask)
         // bypass displaying confirmations for meta-tx's
         do {
             ui_state.menu_idx--;
-            val = ui_state.bundle_ctx->values[menu_to_tx_idx()];
+            val = api.bundle_ctx.values[menu_to_tx_idx()];
         } while (val == 0 && ui_state.menu_idx > 0 &&
                  ui_state.menu_idx < array_sz - 2);
     }

--- a/src/ui/ui_display.c
+++ b/src/ui/ui_display.c
@@ -84,56 +84,57 @@ void display_more_info()
 
 void display_bip_path()
 {
-    uint8_t chars_written = 0, i = 0, isodd = ui_state.api_ctx->bip32_path_length % 2;
-    
+    uint8_t chars_written = 0, i = 0, isodd = api.bip32_path_length % 2;
+
     char *msg = ui_text.top_str;
-    
+
     clear_display();
-    
-    while(i < ui_state.api_ctx->bip32_path_length) {
-        
+
+    while (i < api.bip32_path_length) {
+
         bool ishard = false;
-        
+
         // check if hardened
-        if(ui_state.api_ctx->bip32_path[i] & (1<<31))
+        if (api.bip32_path[i] & (1 << 31))
             ishard = true;
-        
+
         // convert into hex
-        chars_written += int_to_str(ui_state.api_ctx->bip32_path[i] & 0x7fffffff,
-                                    msg + chars_written, 21 - chars_written, 16);
-        
+        chars_written +=
+            int_to_str(api.bip32_path[i] & 0x7fffffff, msg + chars_written,
+                       21 - chars_written, 16);
+
         // check if hardened
-        if(ishard) {
-            if(chars_written == 20) {
+        if (ishard) {
+            if (chars_written == 20) {
                 msg[19] = '?';
                 msg[20] = '\0';
             }
-            else msg[chars_written++] = '\'';
+            else
+                msg[chars_written++] = '\'';
         }
-        
+
         // add spacers
-        if(i < ui_state.api_ctx->bip32_path_length - 1)
-        {
-            snprintf(msg + chars_written, 21-chars_written, " \\ ");
+        if (i < api.bip32_path_length - 1) {
+            snprintf(msg + chars_written, 21 - chars_written, " \\ ");
             chars_written += 3;
-            
+
             // check for overflow
-            if(chars_written > 20) {
+            if (chars_written > 20) {
                 msg[19] = '?';
                 msg[20] = '\0';
             }
         }
-        
+
         i++;
-        
+
         // isodd emulates math.ceil function
-        if(i == (ui_state.api_ctx->bip32_path_length + isodd) / 2) {
+        if (i == (api.bip32_path_length + isodd) / 2) {
             msg[chars_written] = '\0';
             msg = ui_text.bot_str;
             chars_written = 0;
         }
     }
-    
+
     msg[chars_written] = '\0';
     display_glyphs_confirm(ui_glyphs.glyph_up, NULL);
 }
@@ -151,8 +152,8 @@ void display_addr()
     // special overrides
     if (ui_state.menu_idx == 0 && ui_state.state == STATE_DISP_ADDR)
         glyph_on(ui_glyphs.glyph_up);
-    
-    if(ui_state.menu_idx == MENU_ADDR_LEN - 1)
+
+    if (ui_state.menu_idx == MENU_ADDR_LEN - 1)
         glyph_on(ui_glyphs.glyph_down);
 }
 

--- a/src/ui/ui_misc.c
+++ b/src/ui/ui_misc.c
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <string.h>
 #include "ui_types.h"
+#include "api.h"
 #include "storage.h"
 #include "iota/addresses.h"
 
@@ -53,24 +54,24 @@ void abbreviate_addr(char *dest, const char *src, uint8_t len)
 
 char int_to_chr(uint8_t rem, uint8_t radix)
 {
-    if(radix > 16)
+    if (radix > 16)
         return '?';
-    
-    switch(rem) {
-        case 10:
-            return 'a';
-        case 11:
-            return 'b';
-        case 12:
-            return 'c';
-        case 13:
-            return 'd';
-        case 14:
-            return 'e';
-        case 15:
-            return 'f';
-        default:
-            return rem + '0';
+
+    switch (rem) {
+    case 10:
+        return 'a';
+    case 11:
+        return 'b';
+    case 12:
+        return 'c';
+    case 13:
+        return 'd';
+    case 14:
+        return 'e';
+    case 15:
+        return 'f';
+    default:
+        return rem + '0';
     }
 }
 
@@ -114,7 +115,7 @@ int8_t int_to_str(int64_t num, char *str, uint8_t len, uint8_t radix)
         str[i++] = '-';
 
     uint8_t chars_written = i;
-    
+
     str[i--] = '\0';
 
     // reverse the string
@@ -123,7 +124,7 @@ int8_t int_to_str(int64_t num, char *str, uint8_t len, uint8_t radix)
         str[j] = str[i];
         str[i] = c;
     }
-    
+
     return chars_written;
 }
 
@@ -409,7 +410,7 @@ void value_convert_readability()
 
 void display_advanced_tx_value()
 {
-    ui_state.val = ui_state.bundle_ctx->values[menu_to_tx_idx()];
+    ui_state.val = api.bundle_ctx.values[menu_to_tx_idx()];
 
     if (ui_state.val > 0) { // outgoing tx
         // -1 is deny, -2 approve, -3 addr, -4 val of change
@@ -417,8 +418,8 @@ void display_advanced_tx_value()
             char msg[21];
             // write the index along with Change
             snprintf(msg, 21, "Change: [%u]",
-                     (unsigned int)ui_state.bundle_ctx
-                         ->indices[ui_state.bundle_ctx->last_tx_index]);
+                     (unsigned int)
+                         api.bundle_ctx.indices[api.bundle_ctx.last_tx_index]);
 
             write_display(msg, TYPE_STR, TOP);
         }
@@ -429,9 +430,8 @@ void display_advanced_tx_value()
         // input tx (skip meta)
         char msg[21];
         snprintf(msg, 21, "Input: [%u]",
-                 (unsigned int)ui_state.bundle_ctx
-                 ->indices[menu_to_tx_idx()]);
-        
+                 (unsigned int)api.bundle_ctx.indices[menu_to_tx_idx()]);
+
         write_display(msg, TYPE_STR, TOP);
         ui_state.val = -ui_state.val;
     }
@@ -446,7 +446,7 @@ void display_advanced_tx_value()
 void display_advanced_tx_address()
 {
     const unsigned char *addr_bytes =
-        bundle_get_address_bytes(ui_state.bundle_ctx, menu_to_tx_idx());
+        bundle_get_address_bytes(&api.bundle_ctx, menu_to_tx_idx());
 
     get_address_with_checksum(addr_bytes, ui_state.addr);
 
@@ -466,8 +466,8 @@ uint8_t get_tx_arr_sz()
 {
     uint8_t i = 0, counter = 0;
 
-    while (i <= ui_state.bundle_ctx->last_tx_index) {
-        if (ui_state.bundle_ctx->values[i] != 0)
+    while (i <= api.bundle_ctx.last_tx_index) {
+        if (api.bundle_ctx.values[i] != 0)
             counter++;
 
         i++;
@@ -483,9 +483,8 @@ uint8_t menu_to_tx_idx()
     // i counts number of non-meta tx's, j just iterates
     uint8_t i = 0, j = 0;
 
-    while (j <= ui_state.bundle_ctx->last_tx_index &&
-           i <= ui_state.menu_idx / 2) {
-        if (ui_state.bundle_ctx->values[j] != 0) {
+    while (j <= api.bundle_ctx.last_tx_index && i <= ui_state.menu_idx / 2) {
+        if (api.bundle_ctx.values[j] != 0) {
             i++;
         }
         j++;

--- a/src/ui/ui_types.h
+++ b/src/ui/ui_types.h
@@ -3,7 +3,6 @@
 
 #include <stdint.h>
 #include "iota/bundle.h"
-#include "api.h"
 
 #define TYPE_INT 0
 #define TYPE_STR 1
@@ -79,9 +78,6 @@ typedef struct UI_STATE_CTX {
 
     uint8_t backup_state;
     uint8_t backup_menu_idx;
-
-    const BUNDLE_CTX *bundle_ctx;
-    const API_CTX *api_ctx;
 
 } UI_STATE_CTX;
 

--- a/tests/test_mocks.c
+++ b/tests/test_mocks.c
@@ -29,11 +29,6 @@ void ui_display_signing()
 {
 }
 
-void ui_set_api(API_CTX *api_ctx)
-{
-    UNUSED(api_ctx);
-}
-
 void ui_display_address(const unsigned char *addr_bytes)
 {
     UNUSED(addr_bytes);
@@ -42,18 +37,8 @@ void ui_display_address(const unsigned char *addr_bytes)
 // forward declaration
 void user_sign_tx();
 
-void ui_warn_change(BUNDLE_CTX *bundle_ctx)
+void ui_sign_tx()
 {
-    UNUSED(bundle_ctx);
-
-    // the user ignores the warning and signs everything
-    user_sign_tx();
-}
-
-void ui_sign_tx(BUNDLE_CTX *bundle_ctx)
-{
-    UNUSED(bundle_ctx);
-
     // the user signs everything
     user_sign_tx();
 }


### PR DESCRIPTION
Instead of passing the API context as a pointer to the UI use it directly since it is a global variable anyways.