### PR TITLE
Fix add prototypes warnings

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -211,7 +211,7 @@ static unsigned int get_change_tx_index(const BUNDLE_CTX *ctx)
 }
 
 NO_INLINE
-static void io_send_unfinished_bundle()
+static void io_send_unfinished_bundle(void)
 {
     TX_OUTPUT output;
     os_memset(&output, 0, sizeof(TX_OUTPUT));

--- a/src/api.c
+++ b/src/api.c
@@ -264,7 +264,7 @@ unsigned int api_tx(uint8_t p1, const unsigned char *input_data,
     add_tx(input);
     if (!bundle_has_open_txs(&api.bundle_ctx)) {
         // perfectly valid bundle
-        ui_sign_tx(&api.bundle_ctx);
+        ui_sign_tx();
         return IO_ASYNCH_REPLY;
     }
 

--- a/src/api.c
+++ b/src/api.c
@@ -67,7 +67,8 @@ unsigned int api_set_seed(uint8_t p1, const unsigned char *input_data,
         THROW(SW_COMMAND_INVALID_DATA);
     }
 
-    derive_seed_bip32(api.bip32_path, api.bip32_path_length, api.seed_bytes);
+    seed_derive_from_bip32(api.bip32_path, api.bip32_path_length,
+                           api.seed_bytes);
 
     api.state_flags |= SEED_SET;
 

--- a/src/api.h
+++ b/src/api.h
@@ -20,14 +20,14 @@ typedef struct API_CTX {
     /// BIP32 path used for seed derivation
     unsigned int bip32_path[BIP32_PATH_MAX_LEN];
     uint8_t bip32_path_length;
-    
+
     uint8_t security; ///< used security level
-    
+
     unsigned char seed_bytes[NUM_HASH_BYTES]; ///< IOTA seed
-    
+
     BUNDLE_CTX bundle_ctx;
     SIGNING_CTX signing_ctx;
-    
+
     unsigned int state_flags;
 } API_CTX;
 
@@ -118,7 +118,7 @@ GET_APP_CONFIG_OUTPUT;
 
 // no RESET_OUTPUT
 
-void api_initialize();
+void api_initialize(void);
 
 unsigned int api_set_seed(uint8_t p1, const unsigned char *input_data,
                           unsigned int len);
@@ -132,9 +132,9 @@ unsigned int api_get_app_config(uint8_t p1, unsigned char *input_data,
                                 unsigned int len);
 unsigned int api_reset(uint8_t p1, unsigned char *input_data, unsigned int len);
 
-void user_sign_tx();
-void user_deny_tx();
-void user_approve_seed();
-void user_deny_seed();
+void user_sign_tx(void);
+void user_deny_tx(void);
+void user_approve_seed(void);
+void user_deny_seed(void);
 
 #endif // API_H

--- a/src/iota/bundle.c
+++ b/src/iota/bundle.c
@@ -262,7 +262,7 @@ static void compute_hash(BUNDLE_CTX *ctx)
     kerl_squeeze_final_chunk(&sha, ctx->hash);
 }
 
-int bundle_validating_finalize(BUNDLE_CTX *ctx, uint8_t change_index,
+int bundle_validating_finalize(BUNDLE_CTX *ctx, uint8_t change_tx_index,
                                const unsigned char *seed_bytes,
                                uint8_t security)
 {
@@ -270,7 +270,7 @@ int bundle_validating_finalize(BUNDLE_CTX *ctx, uint8_t change_index,
         THROW(INVALID_STATE);
     }
 
-    int result = validate_bundle(ctx, change_index, seed_bytes, security);
+    int result = validate_bundle(ctx, change_tx_index, seed_bytes, security);
     if (result != OK) {
         return result;
     }

--- a/src/iota/bundle.c
+++ b/src/iota/bundle.c
@@ -123,8 +123,8 @@ static inline void normalize_hash(tryte_t *hash_trytes)
     }
 }
 
-void normalize_hash_bytes(const unsigned char *hash_bytes,
-                          tryte_t *normalized_hash_trytes)
+static void normalize_hash_bytes(const unsigned char *hash_bytes,
+                                 tryte_t *normalized_hash_trytes)
 {
     bytes_to_trytes(hash_bytes, normalized_hash_trytes);
     normalize_hash(normalized_hash_trytes);

--- a/src/iota/bundle.h
+++ b/src/iota/bundle.h
@@ -75,7 +75,7 @@ uint32_t bundle_add_tx(BUNDLE_CTX *ctx, int64_t value, const char *tag,
  *  transaction matches the provided address c) the normalized bundle hash does
  *  not contain 'M'.
  *  @param ctx the bundle context used.
- *  @param change_index the index of the change transaction
+ *  @param change_tx_index the index of the change transaction
  *  @param seed_bytes seed used for the addresses
  *  @param security security level used for the addresses
  *  @return true if the bundle is valid, false otherwise

--- a/src/iota/conversion.c
+++ b/src/iota/conversion.c
@@ -33,8 +33,8 @@ static const char tryte_to_char_mapping[] = "NOPQRSTUVWXYZ9ABCDEFGHIJKLM";
 
 /* --------------------- trits > trytes and back */
 // used for bytes to chars and back
-int trytes_to_trits(const tryte_t trytes_in[], trit_t trits_out[],
-                    unsigned int tryte_len)
+static int trytes_to_trits(const tryte_t trytes_in[], trit_t trits_out[],
+                           unsigned int tryte_len)
 {
     for (unsigned int i = 0; i < tryte_len; i++) {
         int8_t idx = (int8_t)trytes_in[i] + 13;
@@ -45,8 +45,8 @@ int trytes_to_trits(const tryte_t trytes_in[], trit_t trits_out[],
     return 0;
 }
 
-int trits_to_trytes(const trit_t trits_in[], tryte_t trytes_out[],
-                    unsigned int trit_len)
+static int trits_to_trytes(const trit_t trits_in[], tryte_t trytes_out[],
+                           unsigned int trit_len)
 {
     for (unsigned int i = 0; i < trit_len / 3; i++) {
         trytes_out[i] = trits_in[i * 3 + 0] + trits_in[i * 3 + 1] * 3 +
@@ -75,8 +75,8 @@ int chars_to_trytes(const char chars_in[], tryte_t trytes_out[],
     return 0;
 }
 
-int trytes_to_chars(const tryte_t trytes_in[], char chars_out[],
-                    unsigned int len)
+static int trytes_to_chars(const tryte_t trytes_in[], char chars_out[],
+                           unsigned int len)
 {
     for (unsigned int i = 0; i < len; i++) {
         chars_out[i] = tryte_to_char_mapping[trytes_in[i] + 13];
@@ -146,7 +146,7 @@ static bool bigint_sub(uint32_t *r, const uint32_t *a, const uint32_t *b)
 /** @brief adds a single 32-bit integer to a long little-endian integer.
  *  @return index of the most significant word which changed during the addition
  */
-unsigned int bigint_add_u32_mem(uint32_t *a, uint32_t summand)
+static unsigned int bigint_add_u32_mem(uint32_t *a, uint32_t summand)
 {
     bool carry = addcarry_u32(&a[0], a[0], summand, false);
     if (carry == false) {

--- a/src/iota/kerl.c
+++ b/src/iota/kerl.c
@@ -24,18 +24,17 @@ void kerl_absorb_chunk(cx_sha3_t *sha3, const unsigned char *bytes)
     kerl_absorb_bytes(sha3, bytes, CX_KECCAK384_SIZE);
 }
 
-void kerl_squeeze_final_chunk(cx_sha3_t *sha3, unsigned char *bytes_out)
+void kerl_squeeze_final_chunk(cx_sha3_t *sha3, unsigned char *bytes)
 {
-    cx_hash((cx_hash_t *)sha3, CX_LAST, bytes_out, 0, bytes_out,
-            CX_KECCAK384_SIZE);
-    bytes_set_last_trit_zero(bytes_out);
+    cx_hash((cx_hash_t *)sha3, CX_LAST, bytes, 0, bytes, CX_KECCAK384_SIZE);
+    bytes_set_last_trit_zero(bytes);
 }
 
-void kerl_squeeze_chunk(cx_sha3_t *sha3, unsigned char *bytes_out)
+void kerl_squeeze_chunk(cx_sha3_t *sha3, unsigned char *bytes)
 {
     unsigned char state_bytes[CX_KECCAK384_SIZE];
 
-    kerl_state_squeeze_chunk(sha3, state_bytes, bytes_out);
+    kerl_state_squeeze_chunk(sha3, state_bytes, bytes);
     kerl_reinitialize(sha3, state_bytes);
 }
 
@@ -55,13 +54,13 @@ static inline void flip_hash_bytes(unsigned char *bytes)
 }
 
 void kerl_state_squeeze_chunk(cx_sha3_t *sha3, unsigned char *state_bytes,
-                              unsigned char *bytes_out)
+                              unsigned char *bytes)
 {
     cx_hash((cx_hash_t *)sha3, CX_LAST, state_bytes, 0, state_bytes,
             CX_KECCAK384_SIZE);
 
-    os_memcpy(bytes_out, state_bytes, CX_KECCAK384_SIZE);
-    bytes_set_last_trit_zero(bytes_out);
+    os_memcpy(bytes, state_bytes, CX_KECCAK384_SIZE);
+    bytes_set_last_trit_zero(bytes);
 
     // flip bytes for multiple squeeze
     flip_hash_bytes(state_bytes);

--- a/src/iota/kerl.h
+++ b/src/iota/kerl.h
@@ -46,7 +46,7 @@ void kerl_squeeze_chunk(cx_sha3_t *sha3, unsigned char *bytes);
  *  @param sha3 the SHA context used for hashing
  *  @param bytes result byte array
  */
-void kerl_squeeze_final_chunk(cx_sha3_t *sha3, unsigned char *bytes_out);
+void kerl_squeeze_final_chunk(cx_sha3_t *sha3, unsigned char *bytes);
 
 /** @brief Squeeze multiple chunks of 48 byte data.
  *  @param sha3 the SHA context used for hashing

--- a/src/iota/seed.c
+++ b/src/iota/seed.c
@@ -4,8 +4,12 @@
 #include "conversion.h"
 #include "kerl.h"
 
-void derive_seed_entropy(const unsigned char *entropy, unsigned int n,
-                         unsigned char *seed_bytes)
+/** @brief Computes a valid IOTA seed based on the provided entropy.
+ *  @param n number of entropy bytes
+ *  @param seed_bytes target array to store the seed in 48 byte encoding
+ */
+static void derive_seed_entropy(const unsigned char *entropy, unsigned int n,
+                                unsigned char *seed_bytes)
 {
     // at least one chunk of entropy required
     if (n < NUM_HASH_BYTES) {
@@ -25,8 +29,8 @@ void derive_seed_entropy(const unsigned char *entropy, unsigned int n,
     kerl_squeeze_final_chunk(&sha, seed_bytes);
 }
 
-void derive_seed_bip32(const unsigned int *path, unsigned int pathLength,
-                       unsigned char *seed_bytes)
+void seed_derive_from_bip32(const unsigned int *path, unsigned int pathLength,
+                            unsigned char *seed_bytes)
 {
     // we only care about privateKey and chain to use as entropy for the seed
     unsigned char entropy[64];

--- a/src/iota/seed.h
+++ b/src/iota/seed.h
@@ -1,14 +1,12 @@
 #ifndef SEED_H
 #define SEED_H
 
-/** @brief Computes a valid IOTA seed based on the provided entropy.
- *  @param n number of entropy bytes
- *  @param seed_bytes target array to store the seed in 48 byte encoding
+/** @brief Derives an IOTA seed from the provided BIP32 path.
+ * @param path array representing the path
+ * @param pathLength nuber of path levels
+ * @param target array for the computed seed as big-endian 48-byte integer
  */
-void derive_seed_entropy(const unsigned char *entropy, unsigned int n,
-                         unsigned char *seed_bytes);
-
-void derive_seed_bip32(const unsigned int *path, unsigned int pathLength,
-                       unsigned char *seed_bytes);
+void seed_derive_from_bip32(const unsigned int *path, unsigned int pathLength,
+                            unsigned char *seed_bytes);
 
 #endif // SEED_H

--- a/src/iota_io.h
+++ b/src/iota_io.h
@@ -4,9 +4,9 @@
 #define BIP32_PATH_MIN_LEN 2
 #define BIP32_PATH_MAX_LEN 5
 
-void io_initialize();
+void io_initialize(void);
 void io_send(const void *ptr, unsigned int length, unsigned short sw);
-unsigned int iota_dispatch();
+unsigned int iota_dispatch(void);
 
 /* ---  CLA  --- */
 

--- a/src/storage.h
+++ b/src/storage.h
@@ -5,11 +5,11 @@
 #include <stdint.h>
 
 /** @brief Initializes the flash storage. */
-void storage_initialize();
+void storage_initialize(void);
 
 /** @brief Returns whether the flash storage has already been initialized.
  *  @return true, if storage is initialized, false otherwise
  */
-bool storage_is_initialized();
+bool storage_is_initialized(void);
 
 #endif // STORAGE_H

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -14,10 +14,10 @@ UI_GLYPH_CTX ui_glyphs;
 UI_STATE_CTX ui_state;
 
 // ----------- local function prototypes
-void ui_transition_state(unsigned int button_mask);
-void ui_build_display();
+static void ui_transition_state(unsigned int button_mask);
+static void ui_build_display(void);
 
-unsigned int bagl_ui_nanos_screen_button(unsigned int, unsigned int);
+static unsigned int bagl_ui_nanos_screen_button(unsigned int, unsigned int);
 
 // *************************
 // Ledger Nano S specific UI
@@ -118,7 +118,7 @@ void ui_force_draw()
                            sizeof(G_io_seproxyhal_spi_buffer), 0);
 }
 
-void ctx_initialize()
+static void ctx_initialize()
 {
     os_memset(&ui_text, 0, sizeof(ui_text));
     os_memset(&ui_glyphs, 0, sizeof(ui_glyphs));
@@ -258,15 +258,16 @@ void ui_restore()
 /* -------------------- SCREEN BUTTON FUNCTIONS ---------------
  ---------------------------------------------------------------
  --------------------------------------------------------------- */
-unsigned int bagl_ui_nanos_screen_button(unsigned int button_mask,
-                                         unsigned int button_mask_counter)
+static unsigned int
+bagl_ui_nanos_screen_button(unsigned int button_mask,
+                            unsigned int button_mask_counter)
 {
     ui_transition_state(button_mask);
 
     return 0;
 }
 
-uint8_t ui_translate_mask(unsigned int button_mask)
+static uint8_t ui_translate_mask(unsigned int button_mask)
 {
     switch (button_mask) {
     case BUTTON_EVT_RELEASED | BUTTON_LEFT:
@@ -285,7 +286,7 @@ uint8_t ui_translate_mask(unsigned int button_mask)
             Special button actions
  ------------------------------------------------------
  --------------------------------------------------- */
-void ui_handle_button(uint8_t button_mask)
+static void ui_handle_button(uint8_t button_mask)
 {
     uint8_t array_sz;
 
@@ -346,7 +347,7 @@ void ui_handle_button(uint8_t button_mask)
          Default display options per state
  ------------------------------------------------------
  --------------------------------------------------- */
-void ui_build_display()
+static void ui_build_display()
 {
     switch (ui_state.state) {
         /* ------------ INIT MENU -------------- */
@@ -405,7 +406,7 @@ void ui_build_display()
         Every button press calls transition_state
  ------------------------------------------------------
  --------------------------------------------------- */
-void ui_transition_state(unsigned int button_mask)
+static void ui_transition_state(unsigned int button_mask)
 {
     uint8_t translated_mask = ui_translate_mask(button_mask);
 

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -17,17 +17,17 @@
 
 void ui_init(bool flash_is_init);
 
-void ui_display_welcome();
-void ui_display_getting_addr();
-void ui_display_validating();
-void ui_display_recv();
-void ui_display_signing();
+void ui_display_welcome(void);
+void ui_display_getting_addr(void);
+void ui_display_validating(void);
+void ui_display_recv(void);
+void ui_display_signing(void);
 void ui_display_address(const unsigned char *addr_bytes);
-void ui_sign_tx();
-void ui_reset();
-void ui_restore();
+void ui_sign_tx(void);
+void ui_reset(void);
+void ui_restore(void);
 
-void ui_render();
-void ui_force_draw();
+void ui_render(void);
+void ui_force_draw(void);
 
 #endif // UI_H

--- a/src/ui/ui_display.h
+++ b/src/ui/ui_display.h
@@ -1,16 +1,16 @@
 #ifndef UI_DISPLAY_H
 #define UI_DISPLAY_H
 
-void display_init();
-void display_welcome();
-void display_about();
-void display_version();
-void display_more_info();
-void display_bip_path();
-void display_addr();     // display pubkey on ledger
-void display_addr_chk(); // display abbrv with chk
-void display_tx_addr();  // display address in tx
-void display_prompt_tx();
-void display_unknown_state();
+void display_init(void);
+void display_welcome(void);
+void display_about(void);
+void display_version(void);
+void display_more_info(void);
+void display_bip_path(void);
+void display_addr(void);     // display pubkey on ledger
+void display_addr_chk(void); // display abbrv with chk
+void display_tx_addr(void);  // display address in tx
+void display_prompt_tx(void);
+void display_unknown_state(void);
 
 #endif // UI_DISPLAY_H

--- a/src/ui/ui_misc.c
+++ b/src/ui/ui_misc.c
@@ -52,7 +52,7 @@ void abbreviate_addr(char *dest, const char *src, uint8_t len)
     dest[13] = '\0';
 }
 
-char int_to_chr(uint8_t rem, uint8_t radix)
+static char int_to_chr(uint8_t rem, uint8_t radix)
 {
     if (radix > 16)
         return '?';
@@ -170,7 +170,7 @@ void write_display(void *o, uint8_t type, uint8_t pos)
 
 
 /* --------- STATE RELATED FUNCTIONS ----------- */
-void clear_text()
+static void clear_text()
 {
     write_display(NULL, TYPE_STR, TOP_H);
     write_display(NULL, TYPE_STR, TOP);
@@ -268,7 +268,7 @@ uint8_t get_num_digits(int64_t val)
     return i;
 }
 
-void str_add_units(char *str, uint8_t unit)
+static void str_add_units(char *str, uint8_t unit)
 {
     char unit_str[] = " i\0\0 Ki\0 Mi\0 Gi\0 Ti\0";
 
@@ -281,7 +281,7 @@ void str_add_units(char *str, uint8_t unit)
     }
 }
 
-char *str_defn_to_ptr(uint8_t str_defn)
+static char *str_defn_to_ptr(uint8_t str_defn)
 {
     char *str_ptr;
 
@@ -307,12 +307,12 @@ char *str_defn_to_ptr(uint8_t str_defn)
     return str_ptr;
 }
 
-bool char_is_num(char c)
+static bool char_is_num(char c)
 {
     return c - '0' >= 0 && c - '0' <= 9;
 }
 
-void str_add_commas(char *str, uint8_t num_digits, bool full)
+static void str_add_commas(char *str, uint8_t num_digits, bool full)
 {
     // largest int that can fit with commas
     // and units at end. if bigger, don't write commas
@@ -365,7 +365,7 @@ void str_add_commas(char *str, uint8_t num_digits, bool full)
 }
 
 // display's full amount in base iotas Ex. 3,040,981,551 i
-void write_full_val(int64_t val, uint8_t str_defn, uint8_t num_digits)
+static void write_full_val(int64_t val, uint8_t str_defn, uint8_t num_digits)
 {
     write_display(&val, TYPE_INT, str_defn);
     str_add_commas(str_defn_to_ptr(str_defn), num_digits, true);
@@ -373,7 +373,8 @@ void write_full_val(int64_t val, uint8_t str_defn, uint8_t num_digits)
 }
 
 // displays brief amount with units Ex. 3.04 Gi
-void write_readable_val(int64_t val, uint8_t str_defn, uint8_t num_digits)
+static void write_readable_val(int64_t val, uint8_t str_defn,
+                               uint8_t num_digits)
 {
     uint8_t base = MIN(((num_digits - 1) / 3), 4);
 

--- a/src/ui/ui_misc.h
+++ b/src/ui/ui_misc.h
@@ -6,9 +6,9 @@
 
 void state_go(uint8_t state, uint8_t idx);
 void state_return(uint8_t state, uint8_t idx);
-void backup_state();
+void backup_state(void);
 void set_backup(uint8_t state, uint8_t menu_idx);
-void restore_state();
+void restore_state(void);
 
 void abbreviate_addr(char *dest, const char *src, uint8_t len);
 void write_display(void *o, uint8_t type, uint8_t pos);
@@ -18,8 +18,8 @@ int8_t int_to_str(int64_t num, char *str, uint8_t len, uint8_t radix);
 void glyph_on(char *c);
 void glyph_off(char *c);
 
-void clear_glyphs();
-void clear_display();
+void clear_glyphs(void);
+void clear_display(void);
 
 void display_glyphs(char *c1, char *c2);
 void display_glyphs_confirm(char *c1, char *c2);
@@ -28,13 +28,13 @@ void write_text_array(char *array, uint8_t len);
 
 uint8_t get_num_digits(int64_t val);
 bool display_value(int64_t val, uint8_t str_defn);
-void value_convert_readability();
-uint8_t get_tx_arr_sz();
-uint8_t menu_to_tx_idx();
+void value_convert_readability(void);
+uint8_t get_tx_arr_sz(void);
+uint8_t menu_to_tx_idx(void);
 void reenter_tx_info(uint8_t state);
 
-void display_advanced_tx_value();
-void display_advanced_tx_address();
+void display_advanced_tx_value(void);
+void display_advanced_tx_address(void);
 
 // Menu creation
 void get_init_menu(char *msg);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,7 @@ include_directories(
     "../src/keccak"
 )
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wshadow -Wcast-align")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wshadow -Wcast-align -Wmissing-prototypes -Wstrict-prototypes")
 
 # enable compilation on host
 add_definitions(

--- a/tests/api_tests.h
+++ b/tests/api_tests.h
@@ -3,6 +3,7 @@
 
 #include "test_common.h"
 #include "api.h"
+#include "seed.h"
 
 #define BIP32_PATH_LENGTH 5
 #define BIP32_PATH                                                             \
@@ -46,7 +47,8 @@ typedef union {
 
 static inline void EXPECT_API_SET_SEED_OK(const char *seed, int security)
 {
-    will_return(derive_seed_bip32, cast_ptr_to_largest_integral_type(seed));
+    will_return(seed_derive_from_bip32,
+                cast_ptr_to_largest_integral_type(seed));
 
     SET_SEED_FIXED_INPUT input = {{security, BIP32_PATH_LENGTH, BIP32_PATH}};
     EXPECT_API_OK(set_seed, 0, input);

--- a/tests/bundle_ext.c
+++ b/tests/bundle_ext.c
@@ -39,8 +39,8 @@ static void bytes_increment_trit_area_81(unsigned char *bytes)
  *  @param num_txs number of elements in the transaction array
  *  @param bundle_ctx target bundle
  */
-void bundle_create(const TX_ENTRY *txs, unsigned int num_txs,
-                      BUNDLE_CTX *bundle_ctx)
+static void bundle_create(const TX_ENTRY *txs, unsigned int num_txs,
+                          BUNDLE_CTX *bundle_ctx)
 {
     bundle_initialize(bundle_ctx, num_txs - 1);
 
@@ -58,7 +58,7 @@ void bundle_create(const TX_ENTRY *txs, unsigned int num_txs,
  *  @return tag increment of the first transaction that was necessary to
  *          generate a valid bundle
  */
-unsigned int bundle_finalize(BUNDLE_CTX *ctx)
+static unsigned int bundle_finalize(BUNDLE_CTX *ctx)
 {
     unsigned int tag_increment = 0;
 

--- a/tests/hash_file.c
+++ b/tests/hash_file.c
@@ -1,3 +1,4 @@
+#include "hash_file.h"
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>

--- a/tests/pubkey_test.c
+++ b/tests/pubkey_test.c
@@ -4,8 +4,8 @@
 #include "api.h"
 #include "iota/conversion.h"
 
-void derive_seed_bip32(const unsigned int *path, unsigned int pathLength,
-                       unsigned char *seed_bytes)
+void seed_derive_from_bip32(const unsigned int *path, unsigned int pathLength,
+                            unsigned char *seed_bytes)
 {
     UNUSED(path);
     UNUSED(pathLength);

--- a/tests/reset_test.c
+++ b/tests/reset_test.c
@@ -4,8 +4,8 @@
 // include the c-file to be able to test static functions
 #include "api.c"
 
-void derive_seed_bip32(const unsigned int *path, unsigned int pathLength,
-                       unsigned char *seed_bytes)
+void seed_derive_from_bip32(const unsigned int *path, unsigned int pathLength,
+                            unsigned char *seed_bytes)
 {
     UNUSED(path);
     UNUSED(pathLength);

--- a/tests/set_seed_test.c
+++ b/tests/set_seed_test.c
@@ -4,8 +4,8 @@
 #include "api.h"
 #include "iota/conversion.h"
 
-void derive_seed_bip32(const unsigned int *path, unsigned int pathLength,
-                       unsigned char *seed_bytes)
+void seed_derive_from_bip32(const unsigned int *path, unsigned int pathLength,
+                            unsigned char *seed_bytes)
 {
     check_expected(path);
     check_expected(pathLength);
@@ -28,10 +28,10 @@ static void test_valid_security_levels(void **state)
 
     for (unsigned int security = 1; security <= 3; security++) {
 
-        expect_memory(derive_seed_bip32, path, path, sizeof(path));
-        expect_value(derive_seed_bip32, pathLength, BIP32_PATH_LENGTH);
+        expect_memory(seed_derive_from_bip32, path, path, sizeof(path));
+        expect_value(seed_derive_from_bip32, pathLength, BIP32_PATH_LENGTH);
 
-        will_return(derive_seed_bip32,
+        will_return(seed_derive_from_bip32,
                     cast_ptr_to_largest_integral_type(PETER_VECTOR.seed));
 
         api_initialize();

--- a/tests/sign_test.c
+++ b/tests/sign_test.c
@@ -6,8 +6,8 @@
 #include "iota/conversion.h"
 #include "iota/signing.h"
 
-void derive_seed_bip32(const unsigned int *path, unsigned int pathLength,
-                       unsigned char *seed_bytes)
+void seed_derive_from_bip32(const unsigned int *path, unsigned int pathLength,
+                            unsigned char *seed_bytes)
 {
     UNUSED(path);
     UNUSED(pathLength);

--- a/tests/test_mocks.c
+++ b/tests/test_mocks.c
@@ -1,7 +1,10 @@
 #include "test_common.h"
 #include <stdio.h>
 #include "api.h"
+#include "seed.h"
+#include "storage.h"
 #include "iota/bundle.h"
+#include "ui/ui.h"
 #include "keccak/sha3.h"
 
 void throw_exception(const char *expression, const char *file, int line)
@@ -35,7 +38,7 @@ void ui_display_address(const unsigned char *addr_bytes)
 }
 
 // forward declaration
-void user_sign_tx();
+void user_sign_tx(void);
 
 void ui_sign_tx()
 {
@@ -52,9 +55,9 @@ bool storage_is_initialized()
     return true;
 }
 
-__attribute__((weak)) void derive_seed_bip32(const unsigned int *path,
-                                             unsigned int pathLength,
-                                             unsigned char *seed_bytes)
+__attribute__((weak)) void seed_derive_from_bip32(const unsigned int *path,
+                                                  unsigned int pathLength,
+                                                  unsigned char *seed_bytes)
 {
     UNUSED(path);
     UNUSED(pathLength);

--- a/tests/tx_test.c
+++ b/tests/tx_test.c
@@ -8,8 +8,8 @@
 // include the c-file to be able to test static functions
 #include "bundle_ext.c"
 
-void derive_seed_bip32(const unsigned int *path, unsigned int pathLength,
-                       unsigned char *seed_bytes)
+void seed_derive_from_bip32(const unsigned int *path, unsigned int pathLength,
+                            unsigned char *seed_bytes)
 {
     UNUSED(path);
     UNUSED(pathLength);


### PR DESCRIPTION
- Make all local-only functions `static`
- Declare functions without arguments with `void`