### PR TITLE
Use unsigned 32-bit integers in APDU API where possible

### DIFF
--- a/demos/python/demo.py
+++ b/demos/python/demo.py
@@ -21,7 +21,7 @@ INS_GET_APP_CONFIG = 0x10
 
 def apdu_command(ins, data, p1=0, p2=0):
     b = bytes(data)
-    
+
     command = bytearray()
     command.append(0x7A)  # Instruction class (1)
     command.append(ins)  # Instruction code (1)
@@ -29,17 +29,24 @@ def apdu_command(ins, data, p1=0, p2=0):
     command.append(len(b))  # length of data (1)
     command.extend(b)  # Command data
     command.append(0)
-    
+
     return command
 
 
 def pack_set_seed_input(bip44_path):
-    struct = Struct("<qq5q")
-    return struct.pack(SECURITY_LEVEL, BIP44_PATH_LENGTH, bip44_path[0], bip44_path[1], bip44_path[2], bip44_path[3], bip44_path[4])
+    struct = Struct("<BI5I")
+    return struct.pack(
+        SECURITY_LEVEL,
+        BIP44_PATH_LENGTH,
+        bip44_path[0],
+        bip44_path[1],
+        bip44_path[2],
+        bip44_path[3],
+        bip44_path[4])
 
 
 def pack_pub_key_input(address_idx):
-    struct = Struct("<q")
+    struct = Struct("<I")
     return struct.pack(address_idx)
 
 
@@ -48,20 +55,11 @@ def unpack_pubkey_output(data):
     return struct.unpack(data)
 
 
-def pack_init_ledger_input(idx1, idx2, idx3, idx4, idx5):
-    struct = Struct("<5q")
-    return struct.pack(idx1, idx2, idx3, idx4, idx5)
-
-
-def unpack_get_indexes(data):
-    struct = Struct("<5q")
-    return struct.unpack(data)
-
-
 def unpack_get_app_config(data):
-    print( len(data))
+    print(len(data))
     struct = Struct("<4B")
     return struct.unpack(data)
+
 
 dongle = getDongle(True)
 exceptionCount = 0
@@ -77,7 +75,8 @@ print("\nInitializing IOTA seed for security-level=%d..." % SECURITY_LEVEL)
 dongle.exchange(apdu_command(INS_SET_SEED, pack_set_seed_input(BIP44_PATH)))
 
 print("\nGenerating address for index=%d..." % SRC_INDEX)
-response = dongle.exchange(apdu_command(INS_PUBKEY, pack_pub_key_input(SRC_INDEX)))
+response = dongle.exchange(apdu_command(
+    INS_PUBKEY, pack_pub_key_input(SRC_INDEX)))
 struct = unpack_pubkey_output(response)
 print("  Address: %s" % struct[0].decode("utf-8"))
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -8,7 +8,7 @@ The IOTA application does not preserve any states or information on application 
 The IO between host and the IOTA application is [APDU](https://en.wikipedia.org/wiki/Smart_card_application_protocol_data_unit) compatible with the following general properties:
 - Everything is encoded in Little-Endian without any padding or alignment.
 - Strings have a fixed length but can be null-terminated if they are shorter.
-- All integer numbers are always encoded in 8 bytes using two's complement representation.
+- Integer numbers are either encoded as unsigned byte (1 byte), unsigned 32-bit (4 bytes) or signed 64-bit (8 bytes) using two's complement representation.
 - Boolean values are encoded in one byte, with `0x00` meaning `false` and any other value meaning `true`.
 - IOTA addresses are always transferred in their 81 character base-27 encoding without checksum information.
 
@@ -30,12 +30,12 @@ The 24 word recovery phrase and the optional passphrase of the Ledger Nano S are
 | INS | byte (1) | `0x01` |
 | P1-P2| byte (2)| ignored |
 | L | byte (1) | Number of bytes to follow | [0, 255]
-| security| signed int64 (8) | set the used security level | [1, 3]
-| length | signed int64 (8) | number of levels in BIP32 path | [2, 5]
-| path[1] | signed int64 (8) | first level of BIP32 path | [0, 2<sup>32</sup>-1]
-| path[2] | signed int64 (8) | second level of BIP32 path | [0, 2<sup>32</sup>-1]
+| security| byte (1) | set the used security level | [1, 3]
+| length | unsigned int32 (4) | number of levels in BIP32 path | [2, 5]
+| path[1] | unsigned int32 (4) | first level of BIP32 path | [0, 2<sup>32</sup>-1]
+| path[2] | unsigned int32 (4) | second level of BIP32 path | [0, 2<sup>32</sup>-1]
 | ... | ... | ... | ...
-| path[length] | signed int64 (8) | last level of BIP32 path | [0, 2<sup>32</sup>-1]
+| path[length] | unsigned int32 (4) | last level of BIP32 path | [0, 2<sup>32</sup>-1]
 
 ### Output
 
@@ -60,7 +60,7 @@ The execution time of `PUBKEY` is about 2s for security level 2.
 | P1 | byte (1) | `0x00`: return address<br/> `0x01`: return and display address |
 | P2| byte (1)| ignored |
 | L | byte (1) | Number of bytes to follow | [0, 255]
-| idx | signed int64 (8) | Index of the address | [0, 2<sup>32</sup>-1]
+| idx | unsigned int32 (4) | Index of the address | [0, 2<sup>32</sup>-1]
 
 ### Output
 
@@ -99,12 +99,12 @@ After a bundle has been set, the state needs to be reset in order to set a new b
 | P1-P2| byte (2)| ignored |
 | L | byte (1) | Number of bytes to follow | [0, 255]
 | address | 81 char string (81) | Base-27 encoding of transaction address |
-| address_idx | signed int64 (8) | Corresponding index of the address;<br> ignored for non-input transactions  | [0, 2<sup>32</sup>-1]
+| address_idx | unsigned int32 (4) | Corresponding index of the address;<br> ignored for non-input transactions  | [0, 2<sup>32</sup>-1]
 | value | signed int64 (8) | Transaction value | < 0 for input transactions<br> &ge; 0 otherwise
 | obsolete_tag | 27 char string (27) | Base-27 encoding of transaction tag |
-| index | signed int64 (8) | Index of that transaction in the bundle | [0, 7]
-| last_index | signed int64 (8) | Last transaction index in the bundle | [1, 7]
-| timestamp | signed int64 (8) | Timestamp | [0, 2<sup>32</sup>-1]
+| index | unsigned int32 (4) | Index of that transaction in the bundle | [0, 7]
+| last_index | unsigned int32 (4) | Last transaction index in the bundle | [1, 7]
+| timestamp | unsigned int32 (4) | Timestamp | [0, 2<sup>32</sup>-1]
 
 ### Output
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -1,4 +1,4 @@
-IOTA Application -- Common Technical Specifications
+IOTA Application &mdash; Common Technical Specifications
 ===================================================
 
 ## About
@@ -12,7 +12,7 @@ The IO between host and the IOTA application is [APDU](https://en.wikipedia.org/
 - Boolean values are encoded in one byte, with `0x00` meaning `false` and any other value meaning `true`.
 - IOTA addresses are always transferred in their 81 character base-27 encoding without checksum information.
 
-## Set the active IOTA seed -- `SET-SEED`
+## Set the active IOTA seed &mdash; `SET-SEED`
 
 ### Description
 
@@ -43,7 +43,7 @@ The 24 word recovery phrase and the optional passphrase of the Ledger Nano S are
 | ----- | ----- | ------- |
 | SW1-SW2 | byte (2) | `0x9000` for success |
 
-## Get Public Key of active Seed -- `PUBKEY`
+## Get Public Key of active Seed &mdash; `PUBKEY`
 
 ### Description
 
@@ -69,7 +69,7 @@ The execution time of `PUBKEY` is about 2s for security level 2.
 | address | 81 char string (81) | Base-27 encoding of public address |
 | SW1-SW2 | byte (2) | `0x9000` for success |
 
-## Add single transaction -- `TX`
+## Add single transaction &mdash; `TX`
 
 ### Description
 
@@ -114,7 +114,7 @@ After a bundle has been set, the state needs to be reset in order to set a new b
 | hash | 81 char string (81) | Base-27 encoding of the bundle hash; undefined if bundle was not finalized |
 | SW1-SW2 | byte (2) | `0x9000` for success |
 
-## Sign a single transaction input -- `SIGN`
+## Sign a single transaction input &mdash; `SIGN`
 
 ### Description
 
@@ -166,7 +166,7 @@ The application version uses [Semantic Versioning](https://semver.org/).
 | app_version_minor | byte (1) | Minor version |
 | app_version_patch | byte (1) | Patch version |
 
-## Reset state -- `RESET`
+## Reset state &mdash; `RESET`
 
 ### Description
 

--- a/src/api.c
+++ b/src/api.c
@@ -106,14 +106,9 @@ unsigned int api_pubkey(uint8_t p1, const unsigned char *input_data,
 
     ui_display_getting_addr();
 
-    uint32_t address_idx;
-    if (!ASSIGN(address_idx, input->address_idx)) {
-        // address index overflow
-        THROW(SW_COMMAND_INVALID_DATA);
-    }
-
     unsigned char addr_bytes[48];
-    get_public_addr(api.seed_bytes, address_idx, api.security, addr_bytes);
+    get_public_addr(api.seed_bytes, input->address_idx, api.security,
+                    addr_bytes);
 
     if (display) {
         ui_display_address(addr_bytes);
@@ -190,13 +185,7 @@ static void add_tx(const TX_INPUT *input)
         THROW(SW_COMMAND_INVALID_DATA);
     }
 
-    uint32_t timestamp;
-    if (!ASSIGN(timestamp, input->timestamp)) {
-        // timestamp overflow
-        THROW(SW_COMMAND_INVALID_DATA);
-    }
-
-    bundle_add_tx(&api.bundle_ctx, input->value, padded_tag, timestamp);
+    bundle_add_tx(&api.bundle_ctx, input->value, padded_tag, input->timestamp);
 }
 
 static unsigned int get_change_tx_index(const BUNDLE_CTX *ctx)
@@ -248,13 +237,8 @@ unsigned int api_tx(uint8_t p1, const unsigned char *input_data,
     // if input, or change address then set internal
     if (input->value < 0 ||
         api.bundle_ctx.current_tx_index == api.bundle_ctx.last_tx_index) {
-        uint32_t address_idx;
-        if (!ASSIGN(address_idx, input->address_idx)) {
-            // index overflow
-            THROW(SW_COMMAND_INVALID_DATA);
-        }
         bundle_set_internal_address(&api.bundle_ctx, input->address,
-                                    address_idx);
+                                    input->address_idx);
     }
     else {
         // ignore index completely

--- a/src/api.c
+++ b/src/api.c
@@ -49,8 +49,8 @@ unsigned int api_set_seed(uint8_t p1, const unsigned char *input_data,
                   BIP32_PATH_MAX_LEN)) {
         THROW(SW_COMMAND_INVALID_DATA);
     }
-    if (len <
-        sizeof(SET_SEED_INPUT) + api.bip32_path_length * sizeof(uint32_t)) {
+    if (len < sizeof(SET_SEED_INPUT) +
+                  api.bip32_path_length * sizeof(input->bip32_path[0])) {
         THROW(SW_INCORRECT_LENGTH);
     }
 

--- a/src/api.c
+++ b/src/api.c
@@ -50,7 +50,7 @@ unsigned int api_set_seed(uint8_t p1, const unsigned char *input_data,
         THROW(SW_COMMAND_INVALID_DATA);
     }
     if (len <
-        sizeof(SET_SEED_INPUT) + api.bip32_path_length * sizeof(int64_t)) {
+        sizeof(SET_SEED_INPUT) + api.bip32_path_length * sizeof(uint32_t)) {
         THROW(SW_INCORRECT_LENGTH);
     }
 

--- a/src/api.h
+++ b/src/api.h
@@ -36,9 +36,9 @@ extern API_CTX api;
 
 typedef IO_STRUCT SET_SEED_INPUT
 {
-    int64_t security;
-    int64_t bip32_path_length;
-    int64_t bip32_path[];
+    uint8_t security;
+    uint8_t bip32_path_length;
+    uint32_t bip32_path[];
 }
 SET_SEED_INPUT;
 
@@ -49,7 +49,7 @@ SET_SEED_INPUT;
 
 typedef IO_STRUCT PUBKEY_INPUT
 {
-    int64_t address_idx;
+    uint32_t address_idx;
 }
 PUBKEY_INPUT;
 
@@ -65,12 +65,12 @@ PUBKEY_OUTPUT;
 typedef IO_STRUCT TX_INPUT
 {
     char address[81];
-    int64_t address_idx;
+    uint32_t address_idx;
     int64_t value;
     char tag[27];
-    int64_t current_index;
-    int64_t last_index;
-    int64_t timestamp;
+    uint32_t current_index;
+    uint32_t last_index;
+    uint32_t timestamp;
 }
 TX_INPUT;
 
@@ -86,7 +86,7 @@ TX_OUTPUT;
 
 typedef IO_STRUCT SIGN_INPUT
 {
-    int64_t transaction_idx;
+    uint32_t transaction_idx;
 }
 SIGN_INPUT;
 

--- a/src/api.h
+++ b/src/api.h
@@ -37,7 +37,7 @@ extern API_CTX api;
 typedef IO_STRUCT SET_SEED_INPUT
 {
     uint8_t security;
-    uint8_t bip32_path_length;
+    uint32_t bip32_path_length;
     uint32_t bip32_path[];
 }
 SET_SEED_INPUT;

--- a/tests/api_tests.h
+++ b/tests/api_tests.h
@@ -37,7 +37,7 @@ typedef union {
     IO_STRUCT
     {
         uint8_t security;
-        uint8_t bip32_path_length;
+        uint32_t bip32_path_length;
         uint32_t bip32_path[BIP32_PATH_LENGTH];
     }
     a;

--- a/tests/api_tests.h
+++ b/tests/api_tests.h
@@ -36,9 +36,9 @@
 typedef union {
     IO_STRUCT
     {
-        int64_t security;
-        int64_t bip32_path_length;
-        int64_t bip32_path[BIP32_PATH_LENGTH];
+        uint8_t security;
+        uint8_t bip32_path_length;
+        uint32_t bip32_path[BIP32_PATH_LENGTH];
     }
     a;
     SET_SEED_INPUT b;

--- a/tests/pubkey_test.c
+++ b/tests/pubkey_test.c
@@ -96,34 +96,6 @@ static void test_change_security(void **state)
     }
 }
 
-static void test_negative_index(void **state)
-{
-    UNUSED(state);
-    static const int security = 2;
-
-    api_initialize();
-    EXPECT_API_SET_SEED_OK(PETER_VECTOR.seed, security);
-    {
-        PUBKEY_INPUT input = {-1};
-
-        EXPECT_API_EXCEPTION(pubkey, 0, input);
-    }
-}
-
-static void test_index_overflow(void **state)
-{
-    UNUSED(state);
-    static const int security = 2;
-
-    api_initialize();
-    EXPECT_API_SET_SEED_OK(PETER_VECTOR.seed, security);
-    {
-        PUBKEY_INPUT input = {(UINT32_MAX + INT64_C(1))};
-
-        EXPECT_API_EXCEPTION(pubkey, 0, input);
-    }
-}
-
 static void test_not_set_seed(void **state)
 {
     UNUSED(state);
@@ -141,8 +113,6 @@ int main(void)
         cmocka_unit_test(test_valid_index_level_two),
         cmocka_unit_test(test_valid_index_level_three),
         cmocka_unit_test(test_change_security),
-        cmocka_unit_test(test_negative_index),
-        cmocka_unit_test(test_index_overflow),
         cmocka_unit_test(test_not_set_seed)};
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/transaction_file.c
+++ b/tests/transaction_file.c
@@ -43,8 +43,8 @@ void test_for_each_bundle(const char *file_name,
 
         for (int i = 0; i <= LAST_TX_INDEX; i++) {
             sscanf(line + offset,
-                   "%81" SCNs27 ",%" SCNd64 ",%" SCNd64 ",%27" SCNs27
-                   ",%" SCNd64 ",%n",
+                   "%81" SCNs27 ",%" SCNu32 ",%" SCNd64 ",%27" SCNs27
+                   ",%" SCNu32 ",%n",
                    tx[i].address, &tx[i].address_idx, &tx[i].value, tx[i].tag,
                    &tx[i].timestamp, &scanned);
 


### PR DESCRIPTION
There is no need to have signed 64-bit integers, if the numbers internally are not supported.